### PR TITLE
add 'full_word' option to .search() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ AhoCorasick.search('foab', trie, function(found_word, data) {
 });
 ```
 
+to match full words only (match 'foobar' but not 'foobarzz'):
+```javascript
+['foobar'].forEach(function(word) { trie.add(word, { word: word }); });
+
+AhoCorasick.search('foobarzz', trie, {full_word:true}, function(found_word, data) {
+   console.log(found_word, data);
+   //empty
+});
+```
+
 Links
 -------------------------------------
 Coffeescript port by @hsujian https://github.com/hsujian/aho-corasick

--- a/src/aho-corasick.js
+++ b/src/aho-corasick.js
@@ -106,7 +106,7 @@ var AhoCorasick = { };
       var current = trie,
           chr, next;
 
-      for (var i = 0, len = string.length; i < len; i++) {
+      for (var i = 0, len = string.length; i <= len; i++) {
 
          chr = string.charAt(i);
          next = current.suffix[chr];
@@ -120,7 +120,7 @@ var AhoCorasick = { };
             if (callback && current && current.is_word) callback(current.value, current.data);
 
             if (current.suffix_link) {
-               i = i - (current.suffix_offset + 1); 
+               i = i - (current.suffix_offset + 1);
                current = current.suffix_link;
             }
             else {
@@ -131,7 +131,7 @@ var AhoCorasick = { };
 
       }
 
-      if (callback && current && current.is_word) callback(current.value, current.data);
+     // if (callback && current && current.is_word) callback(current.value, current.data);
 
    };
 

--- a/src/aho-corasick.js
+++ b/src/aho-corasick.js
@@ -101,8 +101,12 @@ var AhoCorasick = { };
 
    };
 
-   AhoCorasick.search = function(string, trie, callback) {
-
+   AhoCorasick.search = function(string, trie, options, callback) {
+      //allow lazy options paramater
+      if(typeof options=="function"){
+         callback= options;
+      }
+      options= options||{};
       var current = trie,
           chr, next;
 
@@ -116,8 +120,17 @@ var AhoCorasick = { };
             current = next;
          }
          else {
-
-            if (callback && current && current.is_word) callback(current.value, current.data);
+            //it found something..
+            if (callback && current && current.is_word){
+               //ensure the next char is a word-boundary
+               if(options.full_word){
+                  if(chr === '' || chr.match(/[a-zA-Z0-9]/i) === null ){
+                     callback(current.value, current.data);
+                  }
+               }else{
+                 callback(current.value, current.data);
+              }
+            }
 
             if (current.suffix_link) {
                i = i - (current.suffix_offset + 1);
@@ -130,8 +143,6 @@ var AhoCorasick = { };
          }
 
       }
-
-     // if (callback && current && current.is_word) callback(current.value, current.data);
 
    };
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -85,4 +85,16 @@ Tests['Allow attaching multiple bits of data'] = function(test) {
 };
 
 
+Tests['Match full_word only'] = function(test) {
 
+   var trie = new AhoCorasick.TrieNode();
+
+   ['foo', 'bar'].forEach(function(word) { trie.add(word, { word: word } ); });
+
+   AhoCorasick.search('fooz are bar ', trie, {full_word:true}, function(found_word, data) {
+      test.equal(data[0].word, 'bar');
+   });
+
+   test.expect(1);
+   test.done();
+}


### PR DESCRIPTION
hey Tom, thanks for making this library.

I've added a 'full_word' option to the AhoCorasick.search() method, which allows not returning "foobarz" when you're looking for 'foobar'. Essentially it just makes sure the next character is a space or punctuation, before it returns it.

Anyways, hope you like it. I'd also be interested in fixing the multiple-callback situation in the AhoCorasick.search() method, if you're interested. Ideally the callback should only ever fire once right?
cheers!
-s
